### PR TITLE
fix: create pool object outside the actual request function

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -17,6 +17,7 @@ class Client {
   constructor (options) {
     this.options = options
     this.options.host = options.host || 'https://tcm.teambitionapis.com'
+    this.pool = { maxSockets: this.options.maxSockets }
   }
 
   subscribe (topic, _sessionId, token) {
@@ -96,7 +97,7 @@ class Client {
         cert: this.options.certChain,
         key: this.options.privateKey,
         ca: this.options.rootCert,
-        pool: { maxSockets: this.options.maxSockets }
+        pool: this.options.pool
       }, function (err, res, body) {
         if (err) return reject(err)
         if (String(res.statusCode).startsWith('2')) return resolve(body)


### PR DESCRIPTION
Move the creation of the `pool` object to class constructor . Fix #3 .